### PR TITLE
Add disable-flag-exclusive patch

### DIFF
--- a/package/e2fsprogs/0004-disable-flag-exclusive.patch
+++ b/package/e2fsprogs/0004-disable-flag-exclusive.patch
@@ -1,0 +1,19 @@
+diff --git a/resize/main.c b/resize/main.c
+index 396391b..f5e2931 100644
+--- a/resize/main.c
++++ b/resize/main.c
+@@ -398,8 +398,12 @@ int main (int argc, char ** argv)
+ #endif
+ 		io_ptr = unix_io_manager;
+ 
+-	if (!(mount_flags & EXT2_MF_MOUNTED))
+-		io_flags = EXT2_FLAG_RW | EXT2_FLAG_EXCLUSIVE;
++	if (!(mount_flags & EXT2_MF_MOUNTED)) {
++		io_flags = EXT2_FLAG_RW;
++		if (!getenv("DISABLE_FLAG_EXCLUSIVE")) {
++			io_flags |= EXT2_FLAG_EXCLUSIVE;
++		}
++	}
+ 
+ 	io_flags |= EXT2_FLAG_64BITS;
+ 	if (undo_file) {


### PR DESCRIPTION
`resize2fs` fails on Raspberry Pi due to `/dev/mmcblk0p2` (rootfs) not being able to be opened with the `O_EXCL` flag. The `O_EXCL` flag only has an effect when used in conjunction with `O_CREAT`, so it's not necessary in our use case.

This adds a patch to `resize2fs` to not use `O_EXCL` when the environment variable `DISABLE_FLAG_EXCLUSIVE` is set. This will allow someone to manually resize their rootfs from a running Raspberry Pi. There's a bit more needed to finish rancher/os#1084, but this resolves the primary issue.

